### PR TITLE
チャット用にユーザー名と画像をサインアップ時に入力するUIを作成し、firestore, firestorageに保存

### DIFF
--- a/BookList-iOS.xcodeproj/project.pbxproj
+++ b/BookList-iOS.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		785AB27225E9C527000FEEFE /* TapAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 785AB27125E9C527000FEEFE /* TapAction.swift */; };
 		7862C15425E2596D00F1645A /* FirebaseModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862C15325E2596D00F1645A /* FirebaseModelProtocol.swift */; };
 		7862C15825E25B5C00F1645A /* FirestoreUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7862C15725E25B5C00F1645A /* FirestoreUser.swift */; };
+		78769C4425EA28A6007791E0 /* NameValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78769C4325EA28A6007791E0 /* NameValidator.swift */; };
 		78772B3C25B3D37300E6493E /* PurchaseDateValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78772B3B25B3D37300E6493E /* PurchaseDateValidator.swift */; };
 		78772B4E25B3DEBD00E6493E /* Array+Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78772B4D25B3DEBD00E6493E /* Array+Util.swift */; };
 		78772B5425B3E48B00E6493E /* EditBookViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78772B5325B3E48B00E6493E /* EditBookViewModel.swift */; };
@@ -260,6 +261,7 @@
 		785AB27125E9C527000FEEFE /* TapAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapAction.swift; sourceTree = "<group>"; };
 		7862C15325E2596D00F1645A /* FirebaseModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseModelProtocol.swift; sourceTree = "<group>"; };
 		7862C15725E25B5C00F1645A /* FirestoreUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirestoreUser.swift; sourceTree = "<group>"; };
+		78769C4325EA28A6007791E0 /* NameValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NameValidator.swift; sourceTree = "<group>"; };
 		78772B3B25B3D37300E6493E /* PurchaseDateValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseDateValidator.swift; sourceTree = "<group>"; };
 		78772B4D25B3DEBD00E6493E /* Array+Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Util.swift"; sourceTree = "<group>"; };
 		78772B5325B3E48B00E6493E /* EditBookViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditBookViewModel.swift; sourceTree = "<group>"; };
@@ -619,6 +621,7 @@
 		78772B4125B3D56200E6493E /* Account */ = {
 			isa = PBXGroup;
 			children = (
+				78769C4325EA28A6007791E0 /* NameValidator.swift */,
 				78E609F625AAABEA0041B3D0 /* EmailValidator.swift */,
 				78E609FA25AAABF80041B3D0 /* PasswordValidator.swift */,
 			);
@@ -1335,6 +1338,7 @@
 				78E609CB25AA015F0041B3D0 /* LoginRequest.swift in Sources */,
 				78C7F3A725E525C5005E9E2B /* ChatSelectViewController.swift in Sources */,
 				7821A5D425E25C630006DE50 /* FirestoreManager.swift in Sources */,
+				78769C4425EA28A6007791E0 /* NameValidator.swift in Sources */,
 				7862C15425E2596D00F1645A /* FirebaseModelProtocol.swift in Sources */,
 				7820E0AB25AEFC1200A5E6D8 /* ImageLoader.swift in Sources */,
 				78CF3B3525AC48FD00ADBB60 /* BookListDataSource.swift in Sources */,

--- a/BookList-iOS.xcodeproj/project.pbxproj
+++ b/BookList-iOS.xcodeproj/project.pbxproj
@@ -578,10 +578,10 @@
 		7862C15225E2591800F1645A /* Firebase */ = {
 			isa = PBXGroup;
 			children = (
+				7862C15A25E25B6300F1645A /* Model */,
 				78CB209025EA48DD00D4E22D /* FirebaseConfiguration */,
 				7821A5CD25E25BEE0006DE50 /* FirebaseAuth */,
 				7821A5CE25E25C090006DE50 /* Firestore */,
-				7862C15A25E25B6300F1645A /* Model */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";

--- a/BookList-iOS.xcodeproj/project.pbxproj
+++ b/BookList-iOS.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		78E609FB25AAABF80041B3D0 /* PasswordValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E609FA25AAABF80041B3D0 /* PasswordValidator.swift */; };
 		78E60A0025AAAEAC0041B3D0 /* ObservableType+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E609FF25AAAEAC0041B3D0 /* ObservableType+Extension.swift */; };
 		78E80CA625CE4402006580A2 /* BookValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78E80CA525CE4402006580A2 /* BookValidationTests.swift */; };
+		78ED505725EB5C8B0045089C /* FirebaseStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78ED505625EB5C8B0045089C /* FirebaseStorageManager.swift */; };
 		78F940E6259D7E42007C972A /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F940E5259D7E42007C972A /* Router.swift */; };
 		78F940EA259D7EEF007C972A /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F940E9259D7EEF007C972A /* ViewController.swift */; };
 		78F940EE259D995F007C972A /* ResourcesSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F940ED259D995F007C972A /* ResourcesSupport.swift */; };
@@ -353,6 +354,7 @@
 		78E609FA25AAABF80041B3D0 /* PasswordValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordValidator.swift; sourceTree = "<group>"; };
 		78E609FF25AAAEAC0041B3D0 /* ObservableType+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ObservableType+Extension.swift"; sourceTree = "<group>"; };
 		78E80CA525CE4402006580A2 /* BookValidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BookValidationTests.swift; sourceTree = "<group>"; };
+		78ED505625EB5C8B0045089C /* FirebaseStorageManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseStorageManager.swift; sourceTree = "<group>"; };
 		78F940E5259D7E42007C972A /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		78F940E9259D7EEF007C972A /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		78F940ED259D995F007C972A /* ResourcesSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesSupport.swift; sourceTree = "<group>"; };
@@ -581,6 +583,7 @@
 				7862C15A25E25B6300F1645A /* Model */,
 				78CB209025EA48DD00D4E22D /* FirebaseConfiguration */,
 				7821A5CD25E25BEE0006DE50 /* FirebaseAuth */,
+				78ED505525EB5C7A0045089C /* FirebaseStorage */,
 				7821A5CE25E25C090006DE50 /* Firestore */,
 			);
 			path = Firebase;
@@ -1076,6 +1079,14 @@
 			path = Validator;
 			sourceTree = "<group>";
 		};
+		78ED505525EB5C7A0045089C /* FirebaseStorage */ = {
+			isa = PBXGroup;
+			children = (
+				78ED505625EB5C8B0045089C /* FirebaseStorageManager.swift */,
+			);
+			path = FirebaseStorage;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1302,6 +1313,7 @@
 				78DEE7E625AB0BD800219963 /* HomeViewData.swift in Sources */,
 				78E609FB25AAABF80041B3D0 /* PasswordValidator.swift in Sources */,
 				78772B5425B3E48B00E6493E /* EditBookViewModel.swift in Sources */,
+				78ED505725EB5C8B0045089C /* FirebaseStorageManager.swift in Sources */,
 				784B18EF25BD48F80071C32E /* WishListTableViewCell.swift in Sources */,
 				78299CE925E69D0D001868FB /* MyMessageTableViewCell.swift in Sources */,
 				7892EF70259C721F006F7315 /* Resources.swift in Sources */,

--- a/BookList-iOS.xcodeproj/xcshareddata/xcschemes/BookList-iOS.xcscheme
+++ b/BookList-iOS.xcodeproj/xcshareddata/xcschemes/BookList-iOS.xcscheme
@@ -76,7 +76,7 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-FIRAnalyticsDebugDisabled"
+            argument = "-FIRDebugDisabled"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/BookList-iOS/AppResources/Resources/Strings.swift
+++ b/BookList-iOS/AppResources/Resources/Strings.swift
@@ -64,4 +64,9 @@ struct StringResources {
         static let apiBaseUrl = "http://54.250.239.8"
         static let authorization = "Authorization"
     }
+
+    struct Firebase {
+        static let metaDataType = "image/jpeg"
+        static let userIconPath = "user_icon"
+    }
 }

--- a/BookList-iOS/AppResources/Resources/Strings.swift
+++ b/BookList-iOS/AppResources/Resources/Strings.swift
@@ -7,6 +7,7 @@ struct StringResources {
     }
 
     struct App {
+        static var nickName: String { Internal.localizable.nick_name() }
         static var email: String { Internal.localizable.mail_address() }
         static var password: String { Internal.localizable.password() }
         static var logout: String { Internal.localizable.logout() }
@@ -46,6 +47,7 @@ struct StringResources {
         private static let minimumLength = "6"
         private static let maxLength = "30"
 
+        static var nameEmpty: String { Internal.localizable.not_filled(Resources.Strings.App.nickName) }
         static var emailEmpty: String { Internal.localizable.not_filled(Resources.Strings.App.email) }
         static var passwordEmpty: String { Internal.localizable.not_filled(Resources.Strings.App.password) }
         static var titleEmpty: String { Internal.localizable.not_filled(Resources.Strings.App.title) }

--- a/BookList-iOS/AppResources/Support/LocalizedStrings/Localizable.strings
+++ b/BookList-iOS/AppResources/Support/LocalizedStrings/Localizable.strings
@@ -1,4 +1,5 @@
 // MARK: - アプリ
+"nick_name" = "ニックネーム";
 "mail_address" = "メールアドレス";
 "password" = "パスワード";
 "logout" = "ログアウト";

--- a/BookList-iOS/Data/Firebase/FirebaseAuth/FirebaseAuthManager.swift
+++ b/BookList-iOS/Data/Firebase/FirebaseAuth/FirebaseAuthManager.swift
@@ -12,10 +12,10 @@ final class FirebaseAuthManager {
 
     private init() { }
 
-    func createUserWithFirestore(
+    func createUser(
         email: String,
         password: String,
-        user: SignupUser
+        user: FirestoreUser
     ) {
         Auth.auth().createUser(
             withEmail: email,
@@ -24,8 +24,7 @@ final class FirebaseAuthManager {
             if let result = result {
                 FirestoreManager.shared.createUser(
                     documentPath: result.user.uid,
-                    id: user.id,
-                    email: user.email
+                    user: user
                 )
             }
             if let error = error {

--- a/BookList-iOS/Data/Firebase/FirebaseAuth/FirebaseAuthManager.swift
+++ b/BookList-iOS/Data/Firebase/FirebaseAuth/FirebaseAuthManager.swift
@@ -10,7 +10,7 @@ final class FirebaseAuthManager {
         Auth.auth().currentUser
     }
 
-    private init() { }
+    private init() {}
 
     func createUser(
         email: String,

--- a/BookList-iOS/Data/Firebase/FirebaseConfiguration/FirebaseManager.swift
+++ b/BookList-iOS/Data/Firebase/FirebaseConfiguration/FirebaseManager.swift
@@ -4,7 +4,7 @@ final class FirebaseManager {
 
     static let shared = FirebaseManager()
 
-    private init() { }
+    private init() {}
 
     func configure() {
         FirebaseConfiguration.shared.setLoggerLevel(.min)

--- a/BookList-iOS/Data/Firebase/FirebaseStorage/FirebaseStorageManager.swift
+++ b/BookList-iOS/Data/Firebase/FirebaseStorage/FirebaseStorageManager.swift
@@ -1,0 +1,57 @@
+import FirebaseStorage
+
+final class FirebaseStorageManager {
+
+    static let shared = FirebaseStorageManager()
+
+    private let database = Storage.storage()
+
+    private let metaData: StorageMetadata = {
+        let metaData = StorageMetadata()
+        metaData.contentType = Resources.Strings.Firebase.metaDataType
+        return metaData
+    }()
+
+    private init() {}
+
+    func saveUserIconImage(
+        path: String,
+        uploadImage: Data
+    ) {
+        database
+            .reference()
+            .child(Resources.Strings.Firebase.userIconPath)
+            .child(path)
+            .putData(
+                uploadImage,
+                metadata: metaData
+            ) { _, error in
+                if let error = error {
+                    print("FirebaseStorageへのデータの保存に失敗しました: \(error)")
+                    return
+                }
+        }
+    }
+
+    func fetchDownloadUrlString(
+        path: String,
+        completion: @escaping (String) -> Void
+    ) {
+        database
+            .reference()
+            .child(Resources.Strings.Firebase.userIconPath)
+            .child(path)
+            .downloadURL { url, error in
+                if let error = error {
+                    print("FirebaseStorageからのダウンロードに失敗しました: \(error)")
+                }
+                guard
+                    let urlString = url?.absoluteString
+                else {
+                    return
+                }
+
+                completion(urlString)
+            }
+    }
+}

--- a/BookList-iOS/Data/Firebase/Firestore/FirestoreManager.swift
+++ b/BookList-iOS/Data/Firebase/Firestore/FirestoreManager.swift
@@ -8,7 +8,7 @@ final class FirestoreManager {
 
     static let shared = FirestoreManager()
 
-    private init() { }
+    private init() {}
 
     func createUser(
         documentPath: String,
@@ -19,6 +19,7 @@ final class FirestoreManager {
                 id: user.id,
                 name: user.name,
                 email: user.email,
+                imageUrl: user.imageUrl,
                 createdAt: timeStamp()
             ).toDictionary()
         else {

--- a/BookList-iOS/Data/Firebase/Firestore/FirestoreManager.swift
+++ b/BookList-iOS/Data/Firebase/Firestore/FirestoreManager.swift
@@ -2,6 +2,8 @@ import FirebaseFirestore
 
 final class FirestoreManager {
 
+    typealias timeStamp = Timestamp
+
     private let database = Firestore.firestore()
 
     static let shared = FirestoreManager()
@@ -10,13 +12,14 @@ final class FirestoreManager {
 
     func createUser(
         documentPath: String,
-        id: Int,
-        email: String
+        user: FirestoreUser
     ) {
         guard
             let user = FirestoreUser(
-                id: id,
-                email: email
+                id: user.id,
+                name: user.name,
+                email: user.email,
+                createdAt: timeStamp()
             ).toDictionary()
         else {
             return

--- a/BookList-iOS/Data/Firebase/Model/FirebaseModelProtocol.swift
+++ b/BookList-iOS/Data/Firebase/Model/FirebaseModelProtocol.swift
@@ -1,5 +1,7 @@
 import CodableFirebase
 
+extension FirestoreManager.timeStamp: TimestampType {}
+
 protocol FirebaseModelProtocol: Codable {
     func toDictionary() -> [String: Any]?
 }

--- a/BookList-iOS/Data/Firebase/Model/FirestoreUser.swift
+++ b/BookList-iOS/Data/Firebase/Model/FirestoreUser.swift
@@ -2,6 +2,7 @@ struct FirestoreUser: FirebaseModelProtocol {
     var id: Int
     var name: String
     var email: String
+    var imageUrl: String
     var createdAt: FirestoreManager.timeStamp?
 
     static let collectionName = "users"

--- a/BookList-iOS/Data/Firebase/Model/FirestoreUser.swift
+++ b/BookList-iOS/Data/Firebase/Model/FirestoreUser.swift
@@ -1,6 +1,8 @@
 struct FirestoreUser: FirebaseModelProtocol {
     var id: Int
+    var name: String
     var email: String
+    var createdAt: FirestoreManager.timeStamp?
 
     static let collectionName = "users"
 }

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Login/LoginViewController.storyboard
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Login/LoginViewController.storyboard
@@ -17,98 +17,108 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="ehu-uA-PNP">
-                                <rect key="frame" x="56" y="314" width="302" height="268"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="Geu-On-Adz">
+                                <rect key="frame" x="56" y="279" width="302" height="338"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mLd-s0-qfb">
-                                        <rect key="frame" x="0.0" y="0.0" width="302" height="42"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="ehu-uA-PNP">
+                                        <rect key="frame" x="0.0" y="0.0" width="302" height="268"/>
                                         <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="メールアドレス" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rS5-U3-gai" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="mLd-s0-qfb">
+                                                <rect key="frame" x="0.0" y="0.0" width="302" height="42"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="メールアドレス" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rS5-U3-gai" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="32" id="xgC-Ku-qbv"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vNZ-MM-Iyq">
+                                                        <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
+                                                        <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
+                                                        <color key="textColor" systemColor="systemRedColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vK7-Qx-4PW">
+                                                <rect key="frame" x="0.0" y="82" width="302" height="42"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="パスワード" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NvK-EG-EPS" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="32" id="z4B-je-a6y"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress" secureTextEntry="YES"/>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dnm-Rz-UQU">
+                                                        <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
+                                                        <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
+                                                        <color key="textColor" systemColor="systemRedColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tAg-0E-XoJ">
+                                                <rect key="frame" x="0.0" y="164" width="302" height="24"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ABH-Ek-Eng">
+                                                        <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="24" id="YZr-LY-5yv"/>
+                                                            <constraint firstAttribute="width" constant="24" id="mXh-74-Cjt"/>
+                                                        </constraints>
+                                                        <state key="normal" image="Check_Off_Box"/>
+                                                    </button>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="パスワードを表示する" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j4c-jk-SIR">
+                                                        <rect key="frame" x="32" y="0.0" width="270" height="24"/>
+                                                        <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="15"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1aq-gh-JfO" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="228" width="302" height="40"/>
+                                                <color key="backgroundColor" systemColor="systemGreenColor"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="32" id="xgC-Ku-qbv"/>
+                                                    <constraint firstAttribute="height" constant="40" id="cmT-Pi-Lpt"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vNZ-MM-Iyq">
-                                                <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
-                                                <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
-                                                <color key="textColor" systemColor="systemRedColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vK7-Qx-4PW">
-                                        <rect key="frame" x="0.0" y="82" width="302" height="42"/>
-                                        <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="パスワード" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="NvK-EG-EPS" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="32" id="z4B-je-a6y"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="emailAddress" secureTextEntry="YES"/>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dnm-Rz-UQU">
-                                                <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
-                                                <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
-                                                <color key="textColor" systemColor="systemRedColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="tAg-0E-XoJ">
-                                        <rect key="frame" x="0.0" y="164" width="302" height="24"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ABH-Ek-Eng">
-                                                <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="24" id="YZr-LY-5yv"/>
-                                                    <constraint firstAttribute="width" constant="24" id="mXh-74-Cjt"/>
-                                                </constraints>
-                                                <state key="normal" image="Check_Off_Box"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                <state key="normal" title="ログイン">
+                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
                                             </button>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="パスワードを表示する" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j4c-jk-SIR">
-                                                <rect key="frame" x="32" y="0.0" width="270" height="24"/>
-                                                <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="15"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
                                         </subviews>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1aq-gh-JfO" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="228" width="302" height="40"/>
-                                        <color key="backgroundColor" systemColor="systemGreenColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="40" id="cmT-Pi-Lpt"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                        <state key="normal" title="ログイン">
-                                            <color key="titleColor" systemColor="systemBackgroundColor"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                <real key="value" value="10"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                    </button>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="Iw6-b2-xfx">
+                                        <rect key="frame" x="0.0" y="298" width="302" height="40"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q2f-Ro-sP8" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
+                                                <rect key="frame" x="167" y="0.0" width="135" height="40"/>
+                                                <color key="backgroundColor" red="0.0" green="0.0" blue="1" alpha="0.84705882349999995" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
+                                                <state key="normal" title="アカウント作成">
+                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="q2f-Ro-sP8" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
-                                <rect key="frame" x="243" y="638" width="135" height="40"/>
-                                <color key="backgroundColor" red="0.0" green="0.0" blue="1" alpha="0.84705882349999995" colorSpace="custom" customColorSpace="sRGB"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
-                                <state key="normal" title="アカウント作成">
-                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </button>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="VVT-MF-8nR">
                                 <rect key="frame" x="188.5" y="429.5" width="37" height="37"/>
                                 <color key="color" systemColor="systemGrayColor"/>
@@ -117,13 +127,11 @@
                         <viewLayoutGuide key="safeArea" id="JOl-Lw-EHW"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="ehu-uA-PNP" firstAttribute="centerY" secondItem="jlf-NY-6cF" secondAttribute="centerY" id="7NX-oq-Tgq"/>
-                            <constraint firstItem="q2f-Ro-sP8" firstAttribute="centerX" secondItem="jlf-NY-6cF" secondAttribute="centerX" multiplier="1.5" id="8Tz-T1-aHk"/>
-                            <constraint firstItem="JOl-Lw-EHW" firstAttribute="trailing" secondItem="ehu-uA-PNP" secondAttribute="trailing" constant="56" id="FYn-Gy-1bR"/>
+                            <constraint firstItem="Geu-On-Adz" firstAttribute="leading" secondItem="jlf-NY-6cF" secondAttribute="leading" constant="56" id="F9E-kN-Y8a"/>
                             <constraint firstItem="VVT-MF-8nR" firstAttribute="centerY" secondItem="jlf-NY-6cF" secondAttribute="centerY" id="LCi-hO-fTL"/>
+                            <constraint firstItem="Geu-On-Adz" firstAttribute="centerY" secondItem="jlf-NY-6cF" secondAttribute="centerY" id="l8p-qj-2Xb"/>
                             <constraint firstItem="VVT-MF-8nR" firstAttribute="centerX" secondItem="jlf-NY-6cF" secondAttribute="centerX" id="nAW-eY-zP5"/>
-                            <constraint firstItem="ehu-uA-PNP" firstAttribute="leading" secondItem="jlf-NY-6cF" secondAttribute="leading" constant="56" id="wEm-nW-GAz"/>
-                            <constraint firstItem="q2f-Ro-sP8" firstAttribute="top" secondItem="ehu-uA-PNP" secondAttribute="bottom" constant="56" id="y2g-gQ-zsW"/>
+                            <constraint firstAttribute="trailing" secondItem="Geu-On-Adz" secondAttribute="trailing" constant="56" id="tlp-n0-tnl"/>
                         </constraints>
                     </view>
                     <connections>

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/Base.lproj/SignupViewController.storyboard
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/Base.lproj/SignupViewController.storyboard
@@ -23,18 +23,29 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="QZU-5F-nop">
                                         <rect key="frame" x="0.0" y="0.0" width="302" height="80"/>
                                         <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Launch_Image" translatesAutoresizingMaskIntoConstraints="NO" id="J0e-qL-XVB">
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="No_Image" translatesAutoresizingMaskIntoConstraints="NO" id="J0e-qL-XVB">
                                                 <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="80" id="ABm-T2-7nW"/>
                                                     <constraint firstAttribute="width" secondItem="J0e-qL-XVB" secondAttribute="height" id="zAg-fY-3fa"/>
                                                 </constraints>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                        <real key="value" value="1"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                        <color key="value" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                        <real key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
                                             </imageView>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7lY-jc-U89" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
                                                 <rect key="frame" x="120" y="24" width="182" height="32"/>
                                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                                <state key="normal" title="チャット画像">
+                                                <state key="normal" title="チャット画像設定">
                                                     <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 </state>
                                                 <userDefinedRuntimeAttributes>
@@ -228,7 +239,7 @@
             <size key="intrinsicContentSize" width="98" height="21"/>
         </designable>
         <designable name="7lY-jc-U89">
-            <size key="intrinsicContentSize" width="98" height="32"/>
+            <size key="intrinsicContentSize" width="131" height="32"/>
         </designable>
         <designable name="BS3-2F-isb">
             <size key="intrinsicContentSize" width="82" height="20"/>
@@ -248,7 +259,7 @@
     </designables>
     <resources>
         <image name="Check_Off_Box" width="15" height="15"/>
-        <image name="Launch_Image" width="150" height="150"/>
+        <image name="No_Image" width="150" height="150"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/Base.lproj/SignupViewController.storyboard
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/Base.lproj/SignupViewController.storyboard
@@ -17,117 +17,174 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="JQ1-y2-NAh">
-                                <rect key="frame" x="56" y="289" width="302" height="318"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="u19-gL-f2m">
+                                <rect key="frame" x="56" y="172" width="302" height="552"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="NHg-EB-EK9">
-                                        <rect key="frame" x="0.0" y="0.0" width="302" height="42"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="QZU-5F-nop">
+                                        <rect key="frame" x="0.0" y="0.0" width="302" height="80"/>
                                         <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="メールアドレス" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Trg-hS-WGg" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Launch_Image" translatesAutoresizingMaskIntoConstraints="NO" id="J0e-qL-XVB">
+                                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="32" id="PVG-ZG-R24"/>
+                                                    <constraint firstAttribute="width" constant="80" id="ABm-T2-7nW"/>
+                                                    <constraint firstAttribute="width" secondItem="J0e-qL-XVB" secondAttribute="height" id="zAg-fY-3fa"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l0V-IC-vay">
-                                                <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
-                                                <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
-                                                <color key="textColor" systemColor="systemRedColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="THn-pD-1X5">
-                                        <rect key="frame" x="0.0" y="74" width="302" height="42"/>
-                                        <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="パスワード" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BS3-2F-isb" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="32" id="llw-DF-heF"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="emailAddress" secureTextEntry="YES"/>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ysO-oe-8OU">
-                                                <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
-                                                <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
-                                                <color key="textColor" systemColor="systemRedColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vZt-T4-OkY">
-                                        <rect key="frame" x="0.0" y="148" width="302" height="42"/>
-                                        <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="パスワード確認" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Leu-f1-mfE" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="32" id="qlE-eT-pmB"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                <textInputTraits key="textInputTraits" keyboardType="emailAddress" secureTextEntry="YES"/>
-                                            </textField>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RlD-43-zTB">
-                                                <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
-                                                <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
-                                                <color key="textColor" systemColor="systemRedColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="7UE-af-SD8">
-                                        <rect key="frame" x="0.0" y="222" width="302" height="24"/>
-                                        <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YGP-JC-Ey3">
-                                                <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="24" id="Owk-B3-6a5"/>
-                                                    <constraint firstAttribute="height" constant="24" id="oEG-h3-YQ8"/>
-                                                </constraints>
-                                                <state key="normal" image="Check_Off_Box"/>
+                                            </imageView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7lY-jc-U89" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
+                                                <rect key="frame" x="120" y="24" width="182" height="32"/>
+                                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                <state key="normal" title="チャット画像">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
                                             </button>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="パスワードを表示する" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B4B-mK-qUL">
-                                                <rect key="frame" x="32" y="0.0" width="270" height="24"/>
-                                                <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="15"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
                                         </subviews>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bMa-gU-6jb" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="278" width="302" height="40"/>
-                                        <color key="backgroundColor" red="0.0" green="0.0" blue="1" alpha="0.84705882349999995" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="40" id="eRy-as-73E"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                        <state key="normal" title="アカウント作成">
-                                            <color key="titleColor" systemColor="systemBackgroundColor"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                <real key="value" value="10"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                    </button>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="JQ1-y2-NAh">
+                                        <rect key="frame" x="0.0" y="100" width="302" height="392"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="5b5-6s-tbr">
+                                                <rect key="frame" x="0.0" y="0.0" width="302" height="42"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ニックネーム" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3ix-1F-6Ib" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="32" id="VNz-h8-Imm"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                        <textInputTraits key="textInputTraits"/>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="J7e-DN-lvV">
+                                                        <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
+                                                        <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
+                                                        <color key="textColor" systemColor="systemRedColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="NHg-EB-EK9">
+                                                <rect key="frame" x="0.0" y="74" width="302" height="42"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="メールアドレス" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Trg-hS-WGg" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="32" id="PVG-ZG-R24"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress"/>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l0V-IC-vay">
+                                                        <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
+                                                        <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
+                                                        <color key="textColor" systemColor="systemRedColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="THn-pD-1X5">
+                                                <rect key="frame" x="0.0" y="148" width="302" height="42"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="パスワード" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BS3-2F-isb" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="32" id="llw-DF-heF"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress" secureTextEntry="YES"/>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ysO-oe-8OU">
+                                                        <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
+                                                        <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
+                                                        <color key="textColor" systemColor="systemRedColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="vZt-T4-OkY">
+                                                <rect key="frame" x="0.0" y="222" width="302" height="42"/>
+                                                <subviews>
+                                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="パスワード確認" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Leu-f1-mfE" customClass="BorderBottomTextField" customModule="BookList_iOS" customModuleProvider="target">
+                                                        <rect key="frame" x="0.0" y="0.0" width="302" height="32"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="32" id="qlE-eT-pmB"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                                        <textInputTraits key="textInputTraits" keyboardType="emailAddress" secureTextEntry="YES"/>
+                                                    </textField>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RlD-43-zTB">
+                                                        <rect key="frame" x="0.0" y="42" width="302" height="0.0"/>
+                                                        <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="12"/>
+                                                        <color key="textColor" systemColor="systemRedColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="7UE-af-SD8">
+                                                <rect key="frame" x="0.0" y="296" width="302" height="24"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YGP-JC-Ey3">
+                                                        <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="24" id="Owk-B3-6a5"/>
+                                                            <constraint firstAttribute="height" constant="24" id="oEG-h3-YQ8"/>
+                                                        </constraints>
+                                                        <state key="normal" image="Check_Off_Box"/>
+                                                    </button>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="パスワードを表示する" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B4B-mK-qUL">
+                                                        <rect key="frame" x="32" y="0.0" width="270" height="24"/>
+                                                        <fontDescription key="fontDescription" name="HiraMinProN-W6" family="Hiragino Mincho ProN" pointSize="15"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bMa-gU-6jb" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="352" width="302" height="40"/>
+                                                <color key="backgroundColor" red="0.0" green="0.0" blue="1" alpha="0.84705882349999995" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="40" id="eRy-as-73E"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                <state key="normal" title="アカウント作成">
+                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" translatesAutoresizingMaskIntoConstraints="NO" id="4U2-Yo-Tmc">
+                                        <rect key="frame" x="0.0" y="512" width="302" height="40"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZCi-5G-Dq5" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
+                                                <rect key="frame" x="216" y="0.0" width="86" height="40"/>
+                                                <color key="backgroundColor" systemColor="systemGreenColor"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                                <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
+                                                <state key="normal" title="ログイン">
+                                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                        <real key="value" value="10"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="QZU-5F-nop" firstAttribute="centerX" secondItem="u19-gL-f2m" secondAttribute="centerX" id="5B7-eU-bvg"/>
+                                </constraints>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZCi-5G-Dq5" customClass="IBDesignableButton" customModule="BookList_iOS" customModuleProvider="target">
-                                <rect key="frame" x="267.5" y="663" width="86" height="40"/>
-                                <color key="backgroundColor" systemColor="systemGreenColor"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
-                                <inset key="contentEdgeInsets" minX="10" minY="10" maxX="10" maxY="10"/>
-                                <state key="normal" title="ログイン">
-                                    <color key="titleColor" systemColor="systemBackgroundColor"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </button>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="whiteLarge" translatesAutoresizingMaskIntoConstraints="NO" id="Vgx-H0-VTq">
                                 <rect key="frame" x="188.5" y="429.5" width="37" height="37"/>
                                 <color key="color" systemColor="systemGrayColor"/>
@@ -136,13 +193,11 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="JQ1-y2-NAh" secondAttribute="trailing" constant="56" id="1Zi-U5-AXQ"/>
-                            <constraint firstItem="ZCi-5G-Dq5" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" multiplier="1.5" id="BOa-73-zVz"/>
-                            <constraint firstItem="JQ1-y2-NAh" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="56" id="U82-hF-t4R"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="u19-gL-f2m" secondAttribute="trailing" constant="56" id="6z4-mJ-0sm"/>
+                            <constraint firstItem="u19-gL-f2m" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="L0g-bK-2hD"/>
+                            <constraint firstItem="u19-gL-f2m" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="56" id="k3u-89-y8V"/>
                             <constraint firstItem="Vgx-H0-VTq" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="oy8-Gw-rz4"/>
                             <constraint firstItem="Vgx-H0-VTq" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="rC0-H0-zbP"/>
-                            <constraint firstItem="JQ1-y2-NAh" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="vND-9r-DhF"/>
-                            <constraint firstItem="ZCi-5G-Dq5" firstAttribute="top" secondItem="bMa-gU-6jb" secondAttribute="bottom" constant="56" id="wbt-cY-NOI"/>
                         </constraints>
                     </view>
                     <connections>
@@ -154,17 +209,27 @@
                         <outlet property="secureButton" destination="YGP-JC-Ey3" id="dUj-R6-S4h"/>
                         <outlet property="signupButton" destination="bMa-gU-6jb" id="rpJ-ZA-RHh"/>
                         <outlet property="stackView" destination="JQ1-y2-NAh" id="0Fw-jo-wKl"/>
+                        <outlet property="userIconButton" destination="7lY-jc-U89" id="K2U-50-w4y"/>
+                        <outlet property="userIconImageView" destination="J0e-qL-XVB" id="Oct-6G-eJc"/>
+                        <outlet property="userNameTextField" destination="3ix-1F-6Ib" id="PqN-FA-Lwg"/>
                         <outlet property="validateEmailLabel" destination="l0V-IC-vay" id="6OQ-qL-6QZ"/>
                         <outlet property="validatePasswordConfirmationLabel" destination="RlD-43-zTB" id="w9I-ZR-qp4"/>
                         <outlet property="validatePasswordLabel" destination="ysO-oe-8OU" id="Ecb-xq-JXM"/>
+                        <outlet property="validateUserNameLabel" destination="J7e-DN-lvV" id="gbb-Hh-Qt4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-200" y="109"/>
+            <point key="canvasLocation" x="-200.00000000000003" y="108.48214285714285"/>
         </scene>
     </scenes>
     <designables>
+        <designable name="3ix-1F-6Ib">
+            <size key="intrinsicContentSize" width="98" height="21"/>
+        </designable>
+        <designable name="7lY-jc-U89">
+            <size key="intrinsicContentSize" width="98" height="32"/>
+        </designable>
         <designable name="BS3-2F-isb">
             <size key="intrinsicContentSize" width="82" height="20"/>
         </designable>
@@ -183,6 +248,7 @@
     </designables>
     <resources>
         <image name="Check_Off_Box" width="15" height="15"/>
+        <image name="Launch_Image" width="150" height="150"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupUsecase.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupUsecase.swift
@@ -1,3 +1,4 @@
+import Foundation
 import RxSwift
 import RxRelay
 
@@ -46,6 +47,26 @@ final class SignupUsecase {
             email: email,
             password: password,
             user: user
+        )
+    }
+
+    func saveUserIconImage(
+        path: String,
+        uploadImage: Data
+    ) {
+        FirebaseStorageManager.shared.saveUserIconImage(
+            path: path,
+            uploadImage: uploadImage
+        )
+    }
+
+    func fetchDownloadUrlString(
+        path: String,
+        completion: @escaping (String) -> Void
+    ) {
+        FirebaseStorageManager.shared.fetchDownloadUrlString(
+            path: path,
+            completion: completion
         )
     }
 }

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupUsecase.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupUsecase.swift
@@ -29,11 +29,6 @@ final class SignupUsecase {
                     KeychainManager.shared.setToken(response.result.token)
                     self?.loadingRelay.accept(false)
                     self?.resultRelay.accept(.success(response))
-                    self?.createUserForFirebase(
-                        email: email,
-                        password: password,
-                        user: response.result
-                    )
                 },
                 onFailure: { [weak self] error in
                     self?.loadingRelay.accept(false)
@@ -42,12 +37,12 @@ final class SignupUsecase {
             .disposed(by: disposeBag)
     }
 
-    private func createUserForFirebase(
+    func createUserForFirebase(
         email: String,
         password: String,
-        user: SignupResponse.User
+        user: FirestoreUser
     ) {
-        FirebaseAuthManager.shared.createUserWithFirestore(
+        FirebaseAuthManager.shared.createUser(
             email: email,
             password: password,
             user: user

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
@@ -54,6 +54,10 @@ extension SignupViewController {
     }
 
     private func setupButton() {
+        userIconButton.rx.tap.subscribe { [weak self] _ in
+            self?.userIconButtonTapped()
+        }.disposed(by: disposeBag)
+
         secureButton.rx.tap.subscribe { [weak self] _ in
             self?.secureButtonTapped()
         }.disposed(by: disposeBag)
@@ -65,6 +69,18 @@ extension SignupViewController {
         loginButton.rx.tap.subscribe { [weak self] _ in
             self?.loginButtonTapped()
         }.disposed(by: disposeBag)
+    }
+
+    private func userIconButtonTapped() {
+        let photoLibrary = UIImagePickerController.SourceType.photoLibrary
+
+        if UIImagePickerController.isSourceTypeAvailable(photoLibrary) {
+            let picker = UIImagePickerController()
+            picker.sourceType = .photoLibrary
+            picker.allowsEditing = true
+            picker.delegate = self
+            self.present(picker, animated: true)
+        }
     }
 
     private func secureButtonTapped() {
@@ -249,6 +265,22 @@ extension SignupViewController: KeyboardDelegate {
 
     func keyboardDismiss(_ height: CGFloat) {
         view.frame.origin.y != 0 ? (view.frame.origin.y = 0) : ()
+    }
+}
+
+extension SignupViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        if let image = info[.editedImage] as? UIImage {
+            userIconImageView.image = image
+        } else if let originalImage = info[.originalImage] as? UIImage {
+            userIconImageView.image = originalImage
+        }
+        self.dismiss(animated: true)
+    }
+
+    func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        self.dismiss(animated: true)
     }
 }
 

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
@@ -106,6 +106,15 @@ extension SignupViewController {
 
     private func bindValue() {
 
+        userNameTextField.rx.text
+            .validate(NameValidator.self)
+            .map { validate in
+                validate.errorDescription
+            }
+            .skip(2)
+            .bind(to: validateUserNameLabel.rx.text)
+            .disposed(by: disposeBag)
+
         emailTextField.rx.text
             .validate(EmailValidator.self)
             .map { validate in

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
@@ -195,16 +195,23 @@ extension SignupViewController {
                 switch result {
 
                 case .success(let response):
-                    guard let email = self.emailTextField.text,
-                          let password = self.passwordTextField.text
+                    guard
+                        let name = self.userNameTextField.text,
+                        let email = self.emailTextField.text,
+                        let password = self.passwordTextField.text
                     else {
                         return
                     }
 
+                    let user = FirestoreUser(
+                        id: response.result.id,
+                        name: name,
+                        email: email
+                    )
                     self.viewModel.createUserForFirebase(
                         email: email,
                         password: password,
-                        user: response.result
+                        user: user
                     )
 
                     let window = UIApplication.shared.windows.first { $0.isKeyWindow }

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
@@ -5,10 +5,14 @@ import RxCocoa
 final class SignupViewController: UIViewController {
 
     @IBOutlet weak var stackView: UIStackView!
+    @IBOutlet weak var userIconImageView: UIImageView!
+    @IBOutlet weak var userIconButton: IBDesignableButton!
+    @IBOutlet weak var userNameTextField: UITextField!
     @IBOutlet weak var emailTextField: UITextField!
     @IBOutlet weak var passwordTextField: UITextField!
     @IBOutlet weak var passwordConfirmationTextField: UITextField!
     @IBOutlet weak var secureButton: UIButton!
+    @IBOutlet weak var validateUserNameLabel: UILabel!
     @IBOutlet weak var validateEmailLabel: UILabel!
     @IBOutlet weak var validatePasswordLabel: UILabel!
     @IBOutlet weak var validatePasswordConfirmationLabel: UILabel!

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewController.swift
@@ -48,7 +48,10 @@ final class SignupViewController: UIViewController {
 extension SignupViewController {
 
     private func setupTextField() {
-        [emailTextField, passwordTextField, passwordConfirmationTextField].forEach {
+        [
+            userNameTextField, emailTextField,
+            passwordTextField, passwordConfirmationTextField
+        ].forEach {
             $0?.delegate = self
         }
     }
@@ -247,7 +250,9 @@ extension SignupViewController: UITextFieldDelegate {
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-        if emailTextField == textField {
+        if userNameTextField == textField {
+            emailTextField.becomeFirstResponder()
+        } else if emailTextField == textField {
             passwordTextField.becomeFirstResponder()
         } else if passwordTextField == textField {
             passwordConfirmationTextField.becomeFirstResponder()

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewModel.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewModel.swift
@@ -43,9 +43,9 @@ final class SignupViewModel {
     func createUserForFirebase(
         email: String,
         password: String,
-        user: SignupResponse.User
+        user: FirestoreUser
     ) {
-        FirebaseAuthManager.shared.createUserWithFirestore(
+        usecase.createUserForFirebase(
             email: email,
             password: password,
             user: user

--- a/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewModel.swift
+++ b/BookList-iOS/Presentation/Presentation-Domain/Screen/Signup/SignupViewModel.swift
@@ -1,3 +1,4 @@
+import Foundation
 import RxSwift
 import RxRelay
 
@@ -49,6 +50,26 @@ final class SignupViewModel {
             email: email,
             password: password,
             user: user
+        )
+    }
+
+    func saveUserIconImage(
+        path: String,
+        uploadImage: Data
+    ) {
+        usecase.saveUserIconImage(
+            path: path,
+            uploadImage: uploadImage
+        )
+    }
+
+    func fetchDownloadUrlString(
+        path: String,
+        completion: @escaping (String) -> Void
+    ) {
+        usecase.fetchDownloadUrlString(
+            path: path,
+            completion: completion
         )
     }
 }

--- a/BookList-iOS/Presentation/Utility/Validator/Account/NameValidator.swift
+++ b/BookList-iOS/Presentation/Utility/Validator/Account/NameValidator.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum NameValidator: ValidatorProtocol {
+    typealias ValueType = String?
+    typealias ErrorType = NameError
+
+    static func validate(
+        _ value: String?
+    ) -> ValidationResult<NameError> {
+        guard let value = value,
+              !value.isEmpty
+        else {
+            return .invalid(.empty)
+        }
+
+        return .valid
+    }
+}
+
+enum NameError: LocalizedError {
+    case empty
+
+    var errorDescription: String? {
+
+        switch self {
+
+        case .empty:
+            return Resources.Strings.Validator.nameEmpty
+        }
+    }
+}


### PR DESCRIPTION
### 概要
- チャット用にユーザー名と画像をサインアップ時に入力するUIの作成
- 画像をfirestorage, firestoreへ保存
- firestoreへ保存する内容の変更

### ScreenShot
* SIgnup

before | after
:--: | :--:
<img src=https://user-images.githubusercontent.com/70246260/109409956-21b0d300-79da-11eb-88f2-d7b6cc6d90ff.png  width=50%> | <img src=https://user-images.githubusercontent.com/70246260/109409955-1eb5e280-79da-11eb-91f6-369a15ac7072.png  width=50%>

* firestorage
<img width="700" alt="スクリーンショット 2021-02-28 15 33 55" src="https://user-images.githubusercontent.com/70246260/109409989-6e94a980-79da-11eb-9f71-70c7e7f47535.png">

* firestore
<img width="700" alt="スクリーンショット 2021-02-28 15 34 13" src="https://user-images.githubusercontent.com/70246260/109409991-705e6d00-79da-11eb-9dab-e9476cdd0dc0.png">

### issue
close #89 

### 所用時間
- 約4.5時間